### PR TITLE
Cache TLS sessions both on client and server side

### DIFF
--- a/lib/usual/tls/tls_client.c
+++ b/lib/usual/tls/tls_client.c
@@ -188,6 +188,15 @@ int tls_connect_fds(struct tls *ctx, int fd_read, int fd_write,
 	if (tls_configure_keypair(ctx, ctx->ssl_ctx, ctx->config->keypair, 0) != 0)
 		goto err;
 
+	/*
+	 * Enable in-memory session caching for TLS resumption on client side.
+	 */
+	SSL_CTX_set_session_cache_mode(ctx->ssl_ctx,
+				       SSL_SESS_CACHE_CLIENT |
+				       SSL_SESS_CACHE_NO_INTERNAL_STORE);
+	SSL_CTX_sess_set_cache_size(ctx->ssl_ctx, 1024);
+	SSL_CTX_set_timeout(ctx->ssl_ctx, 300);
+
 	if (ctx->config->verify_name) {
 		if (servername == NULL) {
 			tls_set_errorx(ctx, "server name not specified");

--- a/lib/usual/tls/tls_server.c
+++ b/lib/usual/tls/tls_server.c
@@ -155,6 +155,15 @@ int tls_configure_server(struct tls *ctx)
 		goto err;
 	}
 
+	/*
+	 * Enable in-memory session caching for TLS resumption.
+	 */
+	SSL_CTX_set_session_cache_mode(ctx->ssl_ctx,
+				       SSL_SESS_CACHE_SERVER |
+				       SSL_SESS_CACHE_NO_INTERNAL_STORE);
+	SSL_CTX_sess_set_cache_size(ctx->ssl_ctx, 1024);
+	SSL_CTX_set_timeout(ctx->ssl_ctx, 300);
+
 	cert_stack = SSL_load_client_CA_file(ctx->config->ca_file);
 	SSL_CTX_set_client_CA_list(ctx->ssl_ctx, cert_stack);
 


### PR DESCRIPTION
Idea from here https://blog.cloudflare.com/tls-session-resumption-full-speed-and-secure/

Synthetic benchmark results show decrease in TLS session setup time

```
TLS Session Resumption Benchmark
==================================
Host: localhost
Port: 6667
Connections: 20

Testing connectivity...
Connectivity OK

Connection 1: 4.477 ms [TLSv1.3, TLS_AES_256_GCM_SHA384]
Connection 2: 1.954 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 3: 2.100 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 4: 2.031 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 5: 2.084 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 6: 1.865 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 7: 2.047 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 8: 1.997 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 9: 2.130 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 10: 1.935 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 11: 1.917 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 12: 1.868 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 13: 2.026 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 14: 1.994 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 15: 1.867 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 16: 1.820 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 17: 2.026 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 18: 1.806 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 19: 2.088 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)
Connection 20: 1.756 ms [TLSv1.3, TLS_AES_256_GCM_SHA384] (likely resumed)

Results:
--------
First handshake (full):     4.477 ms
Average resumed handshake:  1.964 ms
Speedup:                   2.28x faster
Time saved per connection:  2.513 ms
Total time:                 41.789 ms
Average time per connection: 2.089 ms

Benchmark complete!
```